### PR TITLE
refer to uaccess to prevent build failure

### DIFF
--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -21,6 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "vendor-reset-ioctl.h"
 
 #include <linux/miscdevice.h>
+#include <linux/uaccess.h>
 
 #define VENDOR_RESET_IOCTL_DEVNAME "vendor_reset"
 


### PR DESCRIPTION
Tackling following build glitch for 4.19 kernel:

/var/lib/dkms/vendor-reset/0.0.18/build/src/ioctl.c: In function ‘vendor_reset_ioctl_reset’:
/var/lib/dkms/vendor-reset/0.0.18/build/src/ioctl.c:34:7: error: implicit declaration of function ‘copy_from_user’; did you mean ‘sg_copy_from_buffer’? [-Werror=implicit-function-declaration]
   if (copy_from_user(&iodev, (void __user *)arg, sizeof(iodev)))
       ^~~~~~~~~~~~~~
       sg_copy_from_buffer
cc1: some warnings being treated as errors
make[4]: *** [/usr/src/linux-headers-4.19.0-12-common/scripts/Makefile.build:308: /var/lib/dkms/vendor-reset/0.0.18/build/src/ioctl.o] Error 1
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [/usr/src/linux-headers-4.19.0-12-common/Makefile:1565: _module_/var/lib/dkms/vendor-reset/0.0.18/build] Error 2
make[2]: *** [Makefile:146: sub-make] Error 2
make[1]: *** [Makefile:8: all] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.19.0-12-amd64'
make: *** [Makefile:8: build] Error 2