### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ updating your initrd.
 |AMD|Polaris 10|
 |AMD|Polaris 11|
 |AMD|Polaris 12|
-|AMD|Vega 10| Vega 56/64 |
+|AMD|Vega 10| Vega 56/64/FE |
 |AMD|Vega 20| Radeon VII |
 |AMD|Navi 10| 5600XT, 5700, 5700XT
 |AMD|Navi 12| Pro 5600M |


### PR DESCRIPTION
Adding the 'Vega FE' Common Name for the Vega 10  Family under the Supported Devices section.