### PR TITLE
[core] add support for linux 5.11

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="vendor-reset"
-PACKAGE_VERSION="0.1.0"
+PACKAGE_VERSION="0.1.1"
 BUILT_MODULE_NAME[0]="${PACKAGE_NAME}"
 MAKE[0]="make KDIR=${kernel_source_dir}"
 CLEAN="make KDIR=${kernel_source_dir} clean"

--- a/src/ftrace.c
+++ b/src/ftrace.c
@@ -22,6 +22,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <linux/ftrace.h>
 #include <linux/kprobes.h>
 #include <linux/pci.h>
+#include <linux/version.h>
 
 #include "ftrace.h"
 
@@ -48,8 +49,15 @@ static int resolve_hook_address(struct ftrace_hook *hook)
   return 0;
 }
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0))
 static void notrace fh_trace_thunk(unsigned long ip, unsigned long parent_ip, struct ftrace_ops *ops, struct pt_regs *regs)
 {
+#else
+static void notrace fh_trace_thunk(unsigned long ip, unsigned long parent_ip, struct ftrace_ops *ops, struct ftrace_regs *fregs)
+{
+  struct pt_regs *regs;
+  regs = ftrace_get_regs(fregs);
+#endif
   struct ftrace_hook *hook = to_ftrace_hook(ops);
 
   if (!within_module(parent_ip, THIS_MODULE))


### PR DESCRIPTION
This approach maintains compatibility with previous kernel versions.

Thanks to @justinkb for finding the commit that broke it (torvalds/linux@d19ad07).