### PR TITLE
Allow correct compilation with Clang/LLVM

### DIFF
--- a/src/hook.c
+++ b/src/hook.c
@@ -30,7 +30,11 @@ static bool hook_installed = false;
 static int (*orig_pci_dev_specific_reset)(struct pci_dev *dev, int probe);
 
 /* TCO breaks the hook, we must disable it for this function */
+#if defined(__GNUC__) && !defined(__llvm__)
 __attribute__((optimize("-fno-optimize-sibling-calls")))
+#elif defined(__clang__)
+__attribute__((disable_tail_calls))
+#endif
 static int hooked_pci_dev_specific_reset(struct pci_dev *dev, int probe)
 {
   int ret;


### PR DESCRIPTION
Clang does not understand the GCC function attribute `optimize`, which is used in the module to disable tail-call optimization for the actual hook. This makes Clang emit a warning, which is turned into an error thanks to the default `-Werror` flag added to Linux in 5.15. As Clang has a [dedicated attribute](https://releases.llvm.org/4.0.0/tools/clang/docs/AttributeReference.html#disable-tail-calls-clang-disable-tail-calls) to disable TCO, I added that to the function declaration and added a check for the preprocessor to use the correct `__attribute__` depending on the compiler.

I only stumbled across this when trying to build my kernel with Clang's ThinLTO, which in turn made me compile `vendor-reset` with Clang as well. I've already tested my change on my VM with VFIO and an RX 5700XT, and it seems to be working properly.