### PR TITLE
Fix build on kernel 6.8+

### DIFF
--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -28,6 +28,7 @@
 #include <linux/sched.h>
 #include <linux/slab.h>
 #include <linux/delay.h>
+#include <linux/version.h>
 #include <asm/unaligned.h>
 
 //#include <drm/drm_util.h>
@@ -38,6 +39,10 @@
 #include "atom.h"
 #include "atom-names.h"
 #include "atom-bits.h"
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+#define strscpy strlcpy
+#endif
 
 #define ATOM_COND_ABOVE 0
 #define ATOM_COND_ABOVEOREQUAL 1
@@ -1424,7 +1429,7 @@ struct atom_context *amdgpu_atom_parse(struct card_info *card, void *bios)
 	if (*str != '\0')
 	{
 		pr_info("ATOM BIOS: %s\n", str);
-		strlcpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
+		strscpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
 	}
 
 	return ctx;


### PR DESCRIPTION
Fix an error caused by `strlcpy` on Linux kernel 6.8+ which causes the following issue

```
/var/lib/dkms/vendor-reset/r114.4b466e9/build/src/amd/amdgpu/atom.c:1427:3: error: call to undeclared library function 'strlcpy' with type 'unsigned long (char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

Similar bugs and fixes form [v4l2loopback-dkms FTBS in noble with the latest linux 6.8 kernel ](https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/2052801)