### PR TITLE
replace strlcpy with strscpy

### DIFF
--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -1424,7 +1424,7 @@ struct atom_context *amdgpu_atom_parse(struct card_info *card, void *bios)
 	if (*str != '\0')
 	{
 		pr_info("ATOM BIOS: %s\n", str);
-		strlcpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
+		strscpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
 	}
 
 	return ctx;


### PR DESCRIPTION
module doesn't build with linux 6.8.1,  fails with errors on strlcpy function

vendor-reset/src/amd/amdgpu/atom.c:1427:17: error: implicit declaration of function ‘strlcpy’; did you mean ‘strscpy’? [-Werror=implicit-function-declaration]
 1427 |                 strlcpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
      |                 ^~~~~~~
      |                 strscpy