### PR TITLE
Fix build on Kernel v. 6.12

### DIFF
--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -29,7 +29,7 @@
 #include <linux/slab.h>
 #include <linux/delay.h>
 #include <linux/version.h>
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 
 //#include <drm/drm_util.h>
 //#include <drm/drm_print.h>

--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -29,7 +29,11 @@
 #include <linux/slab.h>
 #include <linux/delay.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+#include <asm/unaligned.h>
+#else
 #include <linux/unaligned.h>
+#endif
 
 //#include <drm/drm_util.h>
 //#include <drm/drm_print.h>


### PR DESCRIPTION
`asm/unaligned.h` has been moved to `linux/unaligned.h` since Linux v. 6.12 [^1], which breaks the build of `vendor-reset` e.g. on NixOS unstable (and likely other distributions, as soon as those switch to 6.12, too).

On my system, the build fails with this error: 

```
/build/source/src/amd/amdgpu/atom.c:32:10: fatal error: asm/unaligned.h: No such file or directory
   32 | #include <asm/unaligned.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [/nix/store/lacdcr5zi7w59f8xsq4cfi41mzgc6dcn-linux-6.12-dev/lib/modules/6.12.0/source/scripts/Makefile.build:229: /build/source/src/amd/amdgpu/atom.o] Error 1
```

[^1]: https://github.com/torvalds/linux/commit/5f60d5f6bbc12e782fac78110b0ee62698f3b576