### PR TITLE
Improved README - Usage for supported and unsupported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,21 @@ Either `modprobe vendor-reset` or add the device to the appropriate place to
 load it at system boot, such as `/etc/modules` (Debian). Consult your
 distribution's documentation as to the best way to perform this.
 
-Execute `echo device_specific > /sys/bus/pci/devices/[REPLACE_WITH_GPU_ID]/reset_method`.
-
-Both of these things should be accomplished by 99-vendor-reset.rules.
-
 **NOTE: ** This module must be loaded EARLY, the default reset the kernel will
 try to perform completely breaks the GPU which this module can not recover from.
 Please consult your distributions documentation on how to do this, for most
 however it will be as simple as adding `vendor-reset` to `/etc/modules` and
 updating your initrd.
+
+Then execute: `echo device_specific > /sys/bus/pci/devices/[REPLACE_WITH_GPU_ID]/reset_method`.
+
+Both of these things are also accomplished by 99-vendor-reset.rules.
+
+If successful, vendor-reset will output to dmesg and prevent the Qemu reset bug:
+
+    qemu-system-x86_64: ../qemu-9.1.2/hw/pci/pci.c:1637: pci_irq_handler: Assertion 0 <= irq_num && irq_num < PCI_NUM_PINS' failed.
+
+Please keep in mind that vendor-reset can only fix the bug before it occurs, not after.
 
 ## Supported Devices
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,19 @@ pattern, or through `dkms` (recommended).
 
     dkms install .
 
+Put `udev/99-vendor-reset.rules` into `/etc/udev/rules.d/99-vendor-reset.rules`
+
+    udevadm control --reload-rules && udevadm trigger
+
 ## Usage
 
 Either `modprobe vendor-reset` or add the device to the appropriate place to
 load it at system boot, such as `/etc/modules` (Debian). Consult your
 distribution's documentation as to the best way to perform this.
+
+Execute `echo device_specific > /sys/bus/pci/devices/[REPLACE_WITH_GPU_ID]/reset_method`.
+
+Both of these things should be accomplished by 99-vendor-reset.rules.
 
 **NOTE: ** This module must be loaded EARLY, the default reset the kernel will
 try to perform completely breaks the GPU which this module can not recover from.
@@ -76,4 +84,20 @@ please first consider two things:
    (see: kernel/drivers/pci/quirk.c)?
 
 If you answer yes to either of these questions this project is not for you.
+
+## Usage with unsupported Devices
+
+Vendor-reset triggers only if your GPU's product ID matches the listed 
+devices above. However many more devices will potentially work, if their 
+product IDs are simply added in device-db.h and 99-vendor-reset.rules, to 
+deploy one of the four currently implemented reset strategies (POLARIS10, 
+VEGA10, VEGA20, NAVI10) in a trial and error process.
+
+Furthermore you can find some useful explanations in the amdgpu source files:
+* [amdgpu.h](https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/amdgpu/amdgpu.h): enum amd_reset_method 
+* [amdgpu_drv.c](https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c): product ID -> chip type
+
+NAVI10 for example makes the most sense to try for iGPUs (integrated), and
+people have done this with success for various models (e.g. [Vega7/5600G](https://forum.proxmox.com/threads/amd-ryzen-5600g-igpu-code-43-error.138665/post-726791) ).
+
 


### PR DESCRIPTION
Please accept this PR or improve your README in a similar way.

Like outlined, there are only a handful of reset strategies for most unsupported cards according to the amdgpu driver, and thus chances are quite high that you can make it work simply via trial and error with one of the already implemented methods in vendor-reset (even if those do not encompass all strategies that the amdgpu driver employs, insofar as this is even so - and even if the strategies are misfit, it can still work somehow and be better than nothing - and even if whatever important, diverse and manifold  use cases people have for doing this, are not immediately or ever at all apparent).

However it is VERY difficult and counter-intuitive to understand this for people from the outside, without some major research and knowledge about hardware. And the whole project is quite suggestive that it is not feasible for a mere end user to make unsupported cards work (which is maybe in the realm of half-truths at best). So it would be prudent and pertinent to briefly explain the situation like this in a practical manner upfront in the README, in order to not send everyone (i.e. mostly less-qualified people) on the roller coaster that entails finding tricks to make unsupported hardware work somehow, or to bail out of trying, despite their cards actually working with very fair chance.