### PR TITLE
Fix compilation errors for DKMS on Linux 6.12.15

### DIFF
--- a/src/amd/amdgpu/amdgpu_bios.c
+++ b/src/amd/amdgpu/amdgpu_bios.c
@@ -28,6 +28,7 @@
 
 #include "atom.h"
 #include "common.h"
+#include "amdgpu_bios.h"
 
 #include <linux/pci.h>
 #include <linux/slab.h>

--- a/src/amd/amdgpu/amdgpu_bios.h
+++ b/src/amd/amdgpu/amdgpu_bios.h
@@ -1,0 +1,11 @@
+#ifndef __AMDGPU_BIOS_H__
+#define __AMDGPU_BIOS_H__
+
+#include <linux/types.h>
+
+struct amd_fake_dev;
+
+bool amdgpu_read_bios(struct amd_fake_dev *adev);
+bool amdgpu_get_bios(struct amd_fake_dev *adev);
+
+#endif

--- a/src/amd/amdgpu/amdgpu_device.c
+++ b/src/amd/amdgpu/amdgpu_device.c
@@ -28,6 +28,7 @@
 
 #include <linux/module.h>
 
+#include "amdgpu_device.h"
 #include "common_defs.h"
 #include "common.h"
 

--- a/src/amd/amdgpu/amdgpu_device.h
+++ b/src/amd/amdgpu/amdgpu_device.h
@@ -1,2 +1,11 @@
+#ifndef __AMDGPU_DEVICE_H__
+#define __AMDGPU_DEVICE_H__
+
+#include <linux/types.h>
+
+struct amd_fake_dev;
+
 void amdgpu_device_vram_access(struct amd_fake_dev *adev, loff_t pos,
                                uint32_t *buf, size_t size, bool write);
+
+#endif

--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -29,7 +29,11 @@
 #include <linux/slab.h>
 #include <linux/delay.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 //#include <drm/drm_util.h>
 //#include <drm/drm_print.h>

--- a/src/amd/amdgpu/common_baco.h
+++ b/src/amd/amdgpu/common_baco.h
@@ -72,5 +72,6 @@ extern bool soc15_baco_program_registers(struct amd_fake_dev *adev,
 																				 const struct soc15_baco_cmd_entry *entry,
 																				 const u32 array_size);
 extern int smu9_baco_get_state(struct amd_fake_dev *adev, enum BACO_STATE *state);
+extern int vega10_baco_set_state(struct amd_fake_dev *adev, enum BACO_STATE state);
 
 #endif

--- a/src/amd/amdgpu/include/nv.h
+++ b/src/amd/amdgpu/include/nv.h
@@ -33,6 +33,8 @@ int nv_set_ip_blocks(struct amd_fake_dev *adev);
 int navi10_reg_base_init(struct amd_fake_dev *adev);
 int navi14_reg_base_init(struct amd_fake_dev *adev);
 int navi12_reg_base_init(struct amd_fake_dev *adev);
+int vega10_reg_base_init(struct amd_fake_dev *adev);
+int vega20_reg_base_init(struct amd_fake_dev *adev);
 int sienna_cichlid_reg_base_init(struct amd_fake_dev *adev);
 void vangogh_reg_base_init(struct amd_fake_dev *adev);
 int dimgrey_cavefish_reg_base_init(struct amd_fake_dev *adev);

--- a/src/amd/amdgpu/vega10_reg_init.c
+++ b/src/amd/amdgpu/vega10_reg_init.c
@@ -25,6 +25,7 @@
 #include "soc15_common.h"
 #include "vega10_ip_offset.h"
 #include "common.h"
+#include "nv.h"
 
 int vega10_reg_base_init(struct amd_fake_dev *adev)
 {

--- a/src/amd/amdgpu/vega20_reg_init.c
+++ b/src/amd/amdgpu/vega20_reg_init.c
@@ -25,6 +25,7 @@
 #include "soc15_common.h"
 #include "vega20_ip_offset.h"
 #include "common.h"
+#include "nv.h"
 
 int vega20_reg_base_init(struct amd_fake_dev *adev)
 {

--- a/src/amd/firmware.h
+++ b/src/amd/firmware.h
@@ -25,4 +25,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 int atom_bios_init(struct amd_fake_dev *adev);
 void atom_bios_fini(struct amd_fake_dev *adev);
 
+u32 amdgpu_io_rreg(struct amd_fake_dev *adev, u32 reg);
+void amdgpu_io_wreg(struct amd_fake_dev *adev, u32 reg, u32 v);
+
 #endif

--- a/src/ftrace.h
+++ b/src/ftrace.h
@@ -42,6 +42,8 @@ struct ftrace_hook
     .function = (replacement),         \
   }
 
+int fh_install_hook(struct ftrace_hook *hook);
+void fh_remove_hook(struct ftrace_hook *hook);
 int fh_install_hooks(struct ftrace_hook *hooks);
 void fh_remove_hooks(struct ftrace_hook *hooks);
 

--- a/src/ioctl.c
+++ b/src/ioctl.c
@@ -17,6 +17,7 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include "ioctl.h"
 #include "vendor-reset-dev.h"
 #include "vendor-reset-ioctl.h"
 

--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -16,8 +16,8 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef _H_VENDOR_RESET_IOCTL
-#define _H_VENDOR_RESET_IOCTL
+#ifndef _H_IOCTL
+#define _H_IOCTL
 
 int vendor_reset_ioctl_init(void);
 void vendor_reset_ioctl_exit(void);


### PR DESCRIPTION
No issues were referenced in this pull request.

There is compilation log:

```
DKMS make.log for vendor-reset-0.1.1 for kernel 6.12.15-production+truenas (x86_64)
Sun Sep 14 14:25:54 CEST 2025
make -C /lib/modules/6.12.15-production+truenas/build M=/var/lib/dkms/vendor-reset/0.1.1/build modules
make[1]: Entering directory '/usr/src/linux-headers-truenas-production-amd64'
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/module.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/vendor-reset-dev.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/ioctl.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/ftrace.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/hook.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/common.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/compat.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/firmware.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/navi10.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/polaris10.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/vega10.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/vega20.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/amdgpu_device.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/amdgpu_discovery.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/amdgpu_bios.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/amdgpu_atomfirmware.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/atom.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/common_baco.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/navi10_reg_init.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/navi12_reg_init.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/navi14_reg_init.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/navi23_reg_init.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/polaris_baco.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/smu7_baco.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/vega10_reg_init.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/src/amd/amdgpu/vega20_reg_init.o
  LD [M]  /var/lib/dkms/vendor-reset/0.1.1/build/vendor-reset.o
  MODPOST /var/lib/dkms/vendor-reset/0.1.1/build/Module.symvers
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/vendor-reset.mod.o
  CC [M]  /var/lib/dkms/vendor-reset/0.1.1/build/.module-common.o
  LD [M]  /var/lib/dkms/vendor-reset/0.1.1/build/vendor-reset.ko
  BTF [M] /var/lib/dkms/vendor-reset/0.1.1/build/vendor-reset.ko
Skipping BTF generation for /var/lib/dkms/vendor-reset/0.1.1/build/vendor-reset.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-headers-truenas-production-amd64'

```

### Summary of Changes
- Resolved all compilation errors when building with DKMS on Linux version 6.12.15.
- Ensured the module compiles cleanly without warnings or errors. 

### Checklist
- [ ] Tests have been added or updated as applicable.
- [ ] Documentation has been updated.  
- [ ] Changes have been reviewed and are ready for integration.