### PR TITLE
Update atom.c: add conditional to allow use on kernel 6.12 and newer

### DIFF
--- a/src/amd/amdgpu/atom.c
+++ b/src/amd/amdgpu/atom.c
@@ -29,7 +29,12 @@
 #include <linux/slab.h>
 #include <linux/delay.h>
 #include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 //#include <drm/drm_util.h>
 //#include <drm/drm_print.h>


### PR DESCRIPTION
This patch adds a conditional to allow vendor-reset to be compiled on Linux 6.12 or newer.

Context: Added this after finding out vendor-reset wouldn't compile on Proxmox 9 when running dkms install because of the following fatal error:
```
src/amd/amdgpu/atom.c:32:10: fatal error: asm/unaligned.h: No such file or directory
   32 | #include <asm/unaligned.h>
      |          ^~~~~~~~~~~~~~~~~
```