### PR TITLE
vega10: Implement PSP Mode 1 Reset

### DIFF
--- a/src/amd/vega10.c
+++ b/src/amd/vega10.c
@@ -30,6 +30,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "common.h"
 #include "compat.h"
 #include "common_baco.h"
+#include "psp_gfx_if.h"
 
 /* MP Apertures, from smu9_smumgr.c */
 #define MP0_Public 0x03800000
@@ -126,6 +127,41 @@ int vega10_baco_set_state(struct amd_fake_dev *adev, enum BACO_STATE state)
   return -EINVAL;
 }
 
+static int amd_vega10_mode1_reset(struct amd_fake_dev *adev)
+{
+  int ret, i;
+  uint32_t offset;
+  uint32_t pci_regs[128];
+  struct pci_dev *pdev = adev_to_amd_private(adev)->vdev->pdev;
+
+  offset = SOC15_REG_OFFSET(MP0, 0, mmMP0_SMN_C2PMSG_64);
+  ret = psp_wait_for(adev, offset, 0x80000000, 0x8000FFFF, false);
+  if (ret) {
+    vr_warn(adev_to_amd_private(adev)->vdev,
+            "psp not working for mode1 reset\n");
+    return ret;
+  }
+
+  /* send mode 1 reset command to PSP */
+  WREG32(offset, GFX_CTRL_CMD_ID_MODE1_RST);
+  msleep(500);
+
+  /* check if PSP came back */
+  offset = SOC15_REG_OFFSET(MP0, 0, mmMP0_SMN_C2PMSG_33);
+  ret = psp_wait_for(adev, offset, 0x80000000, 0x80000000, false);
+
+  if (ret) {
+    vr_warn(adev_to_amd_private(adev)->vdev,
+            "psp mode1 reset completed but PSP not responding\n");
+    return ret;
+  }
+
+  vr_info(adev_to_amd_private(adev)->vdev,
+          "psp mode1 reset succeeded\n");
+
+  return 0;
+}
+
 static int amd_vega10_reset(struct vendor_reset_dev *dev)
 {
   struct amd_vendor_private *priv = amd_private(dev);
@@ -147,13 +183,6 @@ static int amd_vega10_reset(struct vendor_reset_dev *dev)
   {
     vr_err(dev, "amdgpu_get_bios failed: %d\n", ret);
     ret = -ENOTSUPP;
-    goto free_adev;
-  }
-
-  ret = atom_bios_init(adev);
-  if (ret)
-  {
-    vr_err(dev, "atom_bios_init failed: %d\n", ret);
     goto free_adev;
   }
 
@@ -182,6 +211,23 @@ static int amd_vega10_reset(struct vendor_reset_dev *dev)
       smu_resp, sol, mp1_intr ? "yes" : "no",
       psp_bl_ready ? "yes" : "no",
       baco_state == BACO_STATE_IN ? "on" : "off");
+
+  /* Try PSP Mode 1 Reset first. Preferred when the SMU is unresponsive */
+  ret = amd_vega10_mode1_reset(adev);
+  if (!ret)
+  {
+    vr_info(dev, "mode1 reset succeeded, skipping BACO\n");
+    goto free_adev;
+  }
+
+  vr_info(dev, "mode1 reset failed, falling back to BACO\n");
+
+  ret = atom_bios_init(adev);
+  if (ret)
+  {
+    vr_err(dev, "atom_bios_init failed: %d\n", ret);
+    goto free_adev;
+  }
 
   if (sol == ~1L && baco_state != BACO_STATE_IN)
   {

--- a/src/amd/vega10.c
+++ b/src/amd/vega10.c
@@ -96,6 +96,11 @@ static const struct soc15_baco_cmd_entry clean_baco_tbl[] = {
 
 int vega10_baco_set_state(struct amd_fake_dev *adev, enum BACO_STATE state)
 {
+  enum BACO_STATE cur_state;
+
+  smu9_baco_get_state(adev, &cur_state);
+  if (cur_state == state)
+    return 0;
 
   if (state == BACO_STATE_IN)
   {


### PR DESCRIPTION
### Problem

Vega 10 GPUs (RX Vega 56/64) used with VFIO GPU passthrough fail to reset after the first VM shutdown. The guest driver (amdgpu) halts the GPU's SMU during shutdown, and on the next VM start, `vendor-reset`'s BACO reset path fails because it requires a responsive SMU:

```
vfio-pci 0000:0d:00.0: SMU error 0x0
vfio-pci 0000:0d:00.0: AMD_VEGA10: could not get enabled SMU features
vfio-pci 0000:0d:00.0: AMD_VEGA10: failed to reset device
```

This forces users to reboot the entire host between VM sessions.

The existing Vega10 reset path relies entirely on BACO which requires sending `PPSMC_MSG_EnterBaco` to the SMU. When the SMU is halted by the guest driver during VM shutdown, this message times out and the entire reset fails. Unlike Vega20 and Navi, Vega10 had no Mode 1 Reset fallback.

## What this patch does

Add a PSP Mode 1 Reset path for Vega10, based on the approach from:
- The upstream `amdgpu` kernel driver 
(patch from https://lists.freedesktop.org/archives/amd-gfx/2017-September/013203.html)
- The already existing implementation for Vega20 (`src/amd/vega20.c`)

The reset sequence is now:
1. **Try Mode 1 Reset** (PSP-based, does not need SMU) → if success, done
2. **Fall back to BACO** (SMU-based, original path) → only if Mode 1 fails

While at it, also fix a vega10_baco_set_state flaw where a sanity check was missing.
Now setting a BACO state implies checking if the current state is the same as the one we're trying to set.

#### NOTE: this also merges mfrischknecht's #86 (Fix build on Kernel v. 6.12)
so the src actually builds.

## Testing

- **Hardware:** AMD Radeon RX Vega 56 (device ID `0x687f`)
- **Host:** Proxmox VE 9.2.2, kernel 7.0.2-6-pve
- **Guest:** BazziteOS (kernel 6.17)
- **Test:** Start VM → use GPU → shut down VM → start VM again. Repeated multiple times successfully with no host reboot required.