### PR TITLE
vega10: preserve D0 and classify reset state

### DIFF
--- a/src/amd/common.c
+++ b/src/amd/common.c
@@ -21,6 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <linux/pci.h>
 #include <linux/delay.h>
 #include <linux/printk.h>
+#include "amd.h"
 #include "vendor-reset-dev.h"
 #include "soc15_common.h"
 #include "soc15.h"
@@ -132,8 +133,8 @@ int amd_common_post_reset(struct vendor_reset_dev *dev)
     priv->audio_pdev = NULL;
   }
 
-  /* don't try to go to low power if reset failed */
-  if (!dev->reset_ret)
+  /* Keep Vega10 in D0 after reset. */
+  if (!dev->reset_ret && dev->info != AMD_VEGA10)
     pci_set_power_state(pdev, PCI_D3hot);
 
   kfree(priv);

--- a/src/amd/vega10.c
+++ b/src/amd/vega10.c
@@ -200,6 +200,20 @@ static int amd_vega10_reset(struct vendor_reset_dev *dev)
     udelay(1);
   }
 
+  if (sol == 0xFFFFFFFFU)
+  {
+    vr_err(dev, "card is off bus (SOL register reads all ones)\n");
+    ret = -ENODEV;
+    goto free_adev;
+  }
+
+  if (!sol)
+  {
+    vr_info(dev, "card already reset without subsequent POST\n");
+    ret = 0;
+    goto free_adev;
+  }
+
   vr_info(dev, "bus reset disabled? %s\n", (dev->pdev->dev_flags & PCI_DEV_FLAGS_NO_BUS_RESET) ? "yes" : "no");
 
   /* collect some info for logging for now */
@@ -233,17 +247,6 @@ static int amd_vega10_reset(struct vendor_reset_dev *dev)
     vr_err(dev, "atom_bios_init failed: %d\n", ret);
     goto free_adev;
   }
-
-  if (sol == ~1L && baco_state != BACO_STATE_IN)
-  {
-    vr_warn(dev, "timed out waiting for SOL to be valid\n");
-    ret = -EINVAL;
-    goto free_adev;
-  }
-
-  /* if there's no sign of life we usually can't reset */
-  if (!sol)
-    goto free_adev;
 
   /* disable smu features */
   ret = smum_send_msg_to_smc_with_parameter(adev, PPSMC_MSG_GetEnabledSmuFeatures, 0, &features_mask);

--- a/src/vendor-reset-dev.c
+++ b/src/vendor-reset-dev.c
@@ -49,7 +49,7 @@ long vendor_reset_dev_locked(const struct vendor_reset_cfg *cfg,
     .pdev = dev,
     .info = cfg->info
   };
-  int ret;
+  int ret, post_ret;
 
   vr_info(&vdev, "version %d.%d\n",
       cfg->ops->version.major,
@@ -72,7 +72,13 @@ long vendor_reset_dev_locked(const struct vendor_reset_cfg *cfg,
   if (cfg->ops->post_reset)
   {
     vr_info(&vdev, "performing post-reset\n");
-    ret = cfg->ops->post_reset(&vdev);
+    post_ret = cfg->ops->post_reset(&vdev);
+    if (post_ret)
+    {
+      vr_warn(&vdev, "post-reset cleanup failed\n");
+      if (!ret)
+        ret = post_ret;
+    }
   }
 
   vr_info(&vdev, "reset result = %d\n", ret);


### PR DESCRIPTION
Keep Vega10 devices in D0 after reset, reject inaccessible MMIO, and treat zero SOL as an already-reset but un-POSTed card. Preserve reset errors across post-reset cleanup so off-bus failures reach the caller.